### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,13 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }} 🟢
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: "https://registry.npmjs.org"
       - name: Install 🔧
-        run: npm install
-
+        run: npm ci
       - name: Test 🚨
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - main
+      - publish-npm
 
 jobs:
   build:
@@ -12,7 +12,9 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version:
+          - 20.x
+          - 21.x
 
     steps:
       - name: Checkout 🛎️

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: Continuous Integration
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
### `📃` Updated 
1. version `checkout` version 3 to version 4 (latest version)
2. version `setup-node` version 3 to version 4 (latest version)
3. change to use `npm ci` instead `npm install` because `npm ci` installs dependencies directly from the `package-lock.json` file, ignoring the `package.json`. For ensures this project is built using exactly the versions specified in the lock file
4. ~~specific run actions only push to `main` or `master` only~~ specific run actions only push to `master` and `publish-npm`
5. add node version 21 for matrix runner

> **Note** 
> Noticed you're using the `master` and `publish-npm` branches.